### PR TITLE
For screens < 768px, fixed jumbotron and button styling.

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -5,7 +5,12 @@
       background-size: cover;
       background-position: center;
       text-shadow: 0px 2px 2px black;
+	  padding-left: 10px;
+	  padding-right: 10px;
     }
+  .btn {
+      white-space: normal;
+	}  
 }
 
 /* Small */


### PR DESCRIPTION
In main.css, only for screens < 768px :
 - Added left and right padding for tidier text display in jumbotron.
 - Set white-space to normal on .btn so that button text wraps to new line rather than overflowing out of button.


![jumbo](https://cloud.githubusercontent.com/assets/7076027/8635263/bb89ec6a-2813-11e5-9d62-0b1e9cc92761.png)
