### PR TITLE
Slack invalid email handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,6 +137,10 @@ app.post('/chat', function(req, res) {
              {
                req.flash('error', 'An invitation has already been requested for that email address.');
              }
+             else if (body.error.search("invalid_email") >= 0)
+             {
+               req.flash('error', 'Slack does not like the format of that email address. Please try again.');
+             }
              else
              {
                req.flash('error', 'Problem connecting to Slack.  Please contact Hackwimbledon and report "' + body.error + '".');

--- a/index.js
+++ b/index.js
@@ -86,6 +86,11 @@ app.get('/chat',function(req, res) {
 app.post('/chat', function(req, res) {
   if (req.body.slackemail) 
   {
+    // 
+    // Sources used for Slack API call:
+    // https://github.com/outsideris/slack-invite-automation
+    // https://levels.io/slack-typeform-auto-invite-sign-ups/
+    //
     request.post({
         url: 'https://'+ config.slackUrl + '/api/users.admin.invite',
         form: {


### PR DESCRIPTION
Added specific error message for "user enters invalid format email address" on Slack request form.  Most browsers will validate locally and not POST to Slack.  Safari does not do this, so this change makes sure the user receives a less cryptic error message than the default one.
